### PR TITLE
Disable suggestAutoExecute and autoClickIfNeverClicked

### DIFF
--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -1,9 +1,9 @@
 # deploy
 
-1. ensure node version from `.nvmrc`
+1. ensure node v20+
 1. in monorepo root directory: `yarn && yarn build`
 1. follow SSL cert instructions below
-1. in this directory: `yarn run`
+1. in this directory: `yarn start`
 
 ## One-time setup SSL certs for grpc server
 
@@ -11,4 +11,4 @@ grpc requires an SSL connection or it won't run, so we generate a self-signed ce
 
 1. complete CA instructions at: https://connectrpc.com/docs/node/getting-started/#use-the-grpc-protocol-instead-of-the-connect-protocol
 1. if those instructions were successful, then mkcert generated `localhost+2.pem` and `localhost+2-key.pem` in this `packages/service` directory which are expected by the grpc server
-1. `mkcert` must be in `PATH` and then `yarn run`
+1. `mkcert` must be in `PATH` and then `yarn start`

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -28,7 +28,6 @@
     "depcheck": "depcheck",
     "gen": "npx buf generate proto",
     "lint": "yarn eslint . --max-warnings 0 && buf lint",
-    "run": "yarn build && yarn start",
     "start": "yarn start:prod",
     "start:dev": "NODE_EXTRA_CA_CERTS=\"$(mkcert -CAROOT)/rootCA.pem\" dotenvx run -- npx tsx src/server.ts",
     "start:prod": "yarn build && NODE_EXTRA_CA_CERTS=\"$(mkcert -CAROOT)/rootCA.pem\" dotenvx run -- node build/out.js",


### PR DESCRIPTION
suggestAutoExecute and autoClickIfNeverClicked are two transactions
features that help ensure the user only has to click the button once,
regardless of any needed EIP-712 signatures or network additions or
switches.

These features offer a delightful UX where almost all users only have to
click the button once.

However, these features have a critical bug since the recent upgrade to
wagmi v2 where unexpected ExecuteTokenTransfer renders can cause
execute() to be called twice in a row, leading to the user being
prompted to sign duplicate payment transactions (and duplicate payment
if they sign both).

This disables suggestAutoExecute and autoClickIfNeverClicked until they
can be rebuilt safely.