### PR TITLE
Update getConfirmationsToWait.ts

### DIFF
--- a/packages/core/src/getConfirmationsToWait.ts
+++ b/packages/core/src/getConfirmationsToWait.ts
@@ -11,7 +11,7 @@ const confirmationsToWait: { [chainId: number]: number } = isProduction ? {
   [base.id]: 90, // ~3 minutes
   [blast.id]: 90, // ~3 minutes
   [immutableZkEvm.id]: 60, // ~3 minutes
-  [linea.id]: 90, // ~3 minutes
+  [linea.id]: 10, // 2s block time is final. 10 seconds would be conservative, 10 seconds (conservative wait time) ÷ 2 seconds (block time) = 5 blocks, adding 10 block confermation
   [mainnet.id]: 15, // ~3 minutes
   [mode.id]: 60, // ~3 minutes
   [optimism.id]: 90, // ~3 minutes

--- a/packages/core/src/getConfirmationsToWait.ts
+++ b/packages/core/src/getConfirmationsToWait.ts
@@ -11,7 +11,7 @@ const confirmationsToWait: { [chainId: number]: number } = isProduction ? {
   [base.id]: 90, // ~3 minutes
   [blast.id]: 90, // ~3 minutes
   [immutableZkEvm.id]: 60, // ~3 minutes
-  [linea.id]: 10, // 2s block time is final. 10 seconds would be conservative, 10 seconds (conservative wait time) ÷ 2 seconds (block time) = 5 blocks, adding 10 block confermation
+  [linea.id]: 10, // // 20 seconds. This is because Linea has a 2-second block time, and per Linea core team the Linea L2 never reorgs, and they've recommended 10 blocks as sufficiently conservative
   [mainnet.id]: 15, // ~3 minutes
   [mode.id]: 60, // ~3 minutes
   [optimism.id]: 90, // ~3 minutes


### PR DESCRIPTION
2s block time is final. 10 seconds would be conservative, 10 seconds (conservative wait time) ÷ 2 seconds (block time) = 5 blocks, adding 10 block confermation